### PR TITLE
Fix popup width to meet standard wallet extension dimensions

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -447,7 +447,7 @@ const App: React.FC = () => {
   };
 
   return (
-    <div className="w-80 max-w-xs mx-auto bg-white rounded shadow p-4 min-h-screen font-sans">
+    <div className="w-96 max-w-md mx-auto bg-white rounded shadow p-4 min-h-screen font-sans">
       <header className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-bold">Algonius Wallet</h1>
         <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
This PR resolves issue #28 by fixing the popup width to meet standard wallet extension dimensions.

## Changes
- Increased popup width from 320px (w-80) to 384px (w-96) to meet industry standard dimensions
- Updated max-width from 20rem (max-w-xs) to 28rem (max-w-md)
- Improved layout and reduced content crowding

## Technical Details
The change modifies the container div in App.tsx:
- Before: `w-80 max-w-xs` (320px width, 20rem max-width)
- After: `w-96 max-w-md` (384px width, 28rem max-width)

This provides more space for content display and improves the overall user experience.

Fixes #28